### PR TITLE
Add Metafield Type field (#175)

### DIFF
--- a/customcollection_test.go
+++ b/customcollection_test.go
@@ -238,6 +238,7 @@ func TestCustomCollectionCreateMetafield(t *testing.T) {
 		Key:       "app_key",
 		Value:     "app_value",
 		ValueType: "string",
+		Type: "single_line_text_field",
 		Namespace: "affiliates",
 	}
 
@@ -261,6 +262,7 @@ func TestCustomCollectionUpdateMetafield(t *testing.T) {
 		Key:       "app_key",
 		Value:     "app_value",
 		ValueType: "string",
+		Type: "single_line_text_field",
 		Namespace: "affiliates",
 	}
 

--- a/customer_test.go
+++ b/customer_test.go
@@ -372,6 +372,7 @@ func TestCustomerCreateMetafield(t *testing.T) {
 		Key:       "app_key",
 		Value:     "app_value",
 		ValueType: "string",
+		Type: "single_line_text_field",
 		Namespace: "affiliates",
 	}
 
@@ -395,6 +396,7 @@ func TestCustomerUpdateMetafield(t *testing.T) {
 		Key:       "app_key",
 		Value:     "app_value",
 		ValueType: "string",
+		Type: "single_line_text_field",
 		Namespace: "affiliates",
 	}
 

--- a/fixtures/metafield.json
+++ b/fixtures/metafield.json
@@ -5,6 +5,7 @@
     "key": "app_key",
     "value": "app_value",
     "value_type": "string",
+    "type": "single_line_text_field",
     "description": "some amaaazing app's value",
     "owner_id": 1,
     "created_at": "2016-01-01T00:00:00Z",

--- a/metafield.go
+++ b/metafield.go
@@ -39,17 +39,18 @@ type MetafieldServiceOp struct {
 
 // Metafield represents a Shopify metafield.
 type Metafield struct {
-	ID            int64       `json:"id,omitempty"`
-	Key           string      `json:"key,omitempty"`
-	Value         interface{} `json:"value,omitempty"`
-	ValueType     string      `json:"value_type,omitempty"`
-	Namespace     string      `json:"namespace,omitempty"`
-	Description   string      `json:"description,omitempty"`
-	OwnerId       int64       `json:"owner_id,omitempty"`
-	CreatedAt     *time.Time  `json:"created_at,omitempty"`
-	UpdatedAt     *time.Time  `json:"updated_at,omitempty"`
-	OwnerResource string      `json:"owner_resource,omitempty"`
-	AdminGraphqlAPIID string  `json:"admin_graphql_api_id,omitempty"`
+	ID                int64       `json:"id,omitempty"`
+	Key               string      `json:"key,omitempty"`
+	Value             interface{} `json:"value,omitempty"`
+	ValueType         string      `json:"value_type,omitempty"`
+	Type              string      `json:"type,omitempty"`
+	Namespace         string      `json:"namespace,omitempty"`
+	Description       string      `json:"description,omitempty"`
+	OwnerId           int64       `json:"owner_id,omitempty"`
+	CreatedAt         *time.Time  `json:"created_at,omitempty"`
+	UpdatedAt         *time.Time  `json:"updated_at,omitempty"`
+	OwnerResource     string      `json:"owner_resource,omitempty"`
+	AdminGraphqlAPIID string      `json:"admin_graphql_api_id,omitempty"`
 }
 
 // MetafieldResource represents the result from the metafields/X.json endpoint

--- a/metafield_test.go
+++ b/metafield_test.go
@@ -90,6 +90,7 @@ func TestMetafieldGet(t *testing.T) {
 		Key:               "app_key",
 		Value:             "app_value",
 		ValueType:         "string",
+		Type:              "single_line_text_field",
 		Namespace:         "affiliates",
 		Description:       "some amaaazing app's value",
 		OwnerId:           1,
@@ -115,6 +116,7 @@ func TestMetafieldCreate(t *testing.T) {
 		Key:       "warehouse",
 		Value:     "25",
 		ValueType: "integer",
+		Type:      "single_line_text_field",
 	}
 
 	returnedMetafield, err := client.Metafield.Create(metafield)
@@ -136,6 +138,7 @@ func TestMetafieldUpdate(t *testing.T) {
 		ID:        1,
 		Value:     "something new",
 		ValueType: "string",
+		Type: "single_line_text_field",
 	}
 
 	returnedMetafield, err := client.Metafield.Update(metafield)

--- a/order_test.go
+++ b/order_test.go
@@ -549,6 +549,7 @@ func TestOrderCreateMetafield(t *testing.T) {
 		Key:       "app_key",
 		Value:     "app_value",
 		ValueType: "string",
+		Type: "single_line_text_field",
 		Namespace: "affiliates",
 	}
 
@@ -572,6 +573,7 @@ func TestOrderUpdateMetafield(t *testing.T) {
 		Key:       "app_key",
 		Value:     "app_value",
 		ValueType: "string",
+		Type: "single_line_text_field",
 		Namespace: "affiliates",
 	}
 

--- a/page_test.go
+++ b/page_test.go
@@ -224,6 +224,7 @@ func TestPageCreateMetafield(t *testing.T) {
 		Key:       "app_key",
 		Value:     "app_value",
 		ValueType: "string",
+		Type: "single_line_text_field",
 		Namespace: "affiliates",
 	}
 
@@ -247,6 +248,7 @@ func TestPageUpdateMetafield(t *testing.T) {
 		Key:       "app_key",
 		Value:     "app_value",
 		ValueType: "string",
+		Type: "single_line_text_field",
 		Namespace: "affiliates",
 	}
 

--- a/product_test.go
+++ b/product_test.go
@@ -393,6 +393,7 @@ func TestProductCreateMetafield(t *testing.T) {
 		Key:       "app_key",
 		Value:     "app_value",
 		ValueType: "string",
+		Type: "single_line_text_field",
 		Namespace: "affiliates",
 	}
 
@@ -416,6 +417,7 @@ func TestProductUpdateMetafield(t *testing.T) {
 		Key:       "app_key",
 		Value:     "app_value",
 		ValueType: "string",
+		Type: "single_line_text_field",
 		Namespace: "affiliates",
 	}
 

--- a/smartcollection_test.go
+++ b/smartcollection_test.go
@@ -241,6 +241,7 @@ func TestSmartCollectionCreateMetafield(t *testing.T) {
 		Key:       "app_key",
 		Value:     "app_value",
 		ValueType: "string",
+		Type: "single_line_text_field",
 		Namespace: "affiliates",
 	}
 
@@ -264,6 +265,7 @@ func TestSmartCollectionUpdateMetafield(t *testing.T) {
 		Key:       "app_key",
 		Value:     "app_value",
 		ValueType: "string",
+		Type: "single_line_text_field",
 		Namespace: "affiliates",
 	}
 

--- a/variant_test.go
+++ b/variant_test.go
@@ -321,6 +321,7 @@ func TestVariantCreateMetafield(t *testing.T) {
 		Key:       "app_key",
 		Value:     "app_value",
 		ValueType: "string",
+		Type: "single_line_text_field",
 		Namespace: "affiliates",
 	}
 
@@ -344,6 +345,7 @@ func TestVariantUpdateMetafield(t *testing.T) {
 		Key:       "app_key",
 		Value:     "app_value",
 		ValueType: "string",
+		Type: "single_line_text_field",
 		Namespace: "affiliates",
 	}
 


### PR DESCRIPTION
- prior to this change it was impossible to call the Shopify API
  with this field since it was newly added in 2021-07